### PR TITLE
Force PTT refresh screen when going to some post index

### DIFF
--- a/PyPtt/_api_get_post.py
+++ b/PyPtt/_api_get_post.py
@@ -70,6 +70,8 @@ def get_post(
                 cmd_list.append(search_condition_)
                 cmd_list.append(command.Enter)
 
+        cmd_list.append(str(max(1, post_index - 100)))
+        cmd_list.append(command.Enter)
         cmd_list.append(str(post_index))
 
     cmd_list.append(command.Enter)


### PR DESCRIPTION
進入 PTT 看板，並輸入文章 index 後，如果這個 index 跟進入畫面是在同一頁的話，最下面的「文章選讀」的 bar 會消失，參考下面兩張圖：

1. 剛進入看板，下面的 bar 還在。
![image](https://user-images.githubusercontent.com/13679570/91029215-0f239e80-e631-11ea-8575-842223ce8a7c.png)

2. 進入看板並輸入 `414[enter]` 後，下面的 bar 消失了。
![image](https://user-images.githubusercontent.com/13679570/91029057-e13e5a00-e630-11ea-86d4-27879296ade7.png)

在少了下面的 bar 的情況下，`_api_get_post()` 拿已被刪除的文章的 info 的時候，會等到 timeout 才確定文章已被刪除。

所以這個 commit 就是先去 `post_index-100`，再去 `post_index` 來保證下面的 bar 一定在。這樣就不用等到 timeout，速度快很多。