### PR TITLE
修正小天使發錢給小主人會失敗的特例

### DIFF
--- a/PyPtt/_api_give_money.py
+++ b/PyPtt/_api_give_money.py
@@ -67,6 +67,11 @@ def give_money(
             response=api._Password + command.Enter
         ),
         connect_core.TargetUnit(
+            i18n.AnonymousTransaction,
+            '他是你的小主人，是否匿名？',
+            response='n' + command.Enter
+        ),
+        connect_core.TargetUnit(
             i18n.InputMoney,
             '要給他多少Ptt幣呢?',
             response=command.Tab + str(money) + command.Enter

--- a/PyPtt/i18n.py
+++ b/PyPtt/i18n.py
@@ -194,6 +194,7 @@ CatchBottomPostSuccess = None
 ConfirmDelete = None
 DeleteSuccess = None
 DeletedPost = None
+AnonymousTransaction = None
 
 
 def specific_load(input_language, lang_list):
@@ -1279,6 +1280,12 @@ def load(input_lang):
     DeletedPost = specific_load(input_lang, [
         '已刪除文章',
         'Deleted Post',
+    ])
+
+    global AnonymousTransaction
+    AnonymousTransaction = specific_load(input_lang, [
+        '不使用匿名交易',
+        'Transaction without Anomalous',
     ])
 
     # No changes have been made to any settings


### PR DESCRIPTION
如果使用者是小天使而發錢的對象是小主人的話PTT會多問一句`他是你的小主人，是否匿名？`
現行的並沒有處理這個特例，會造成後續的錯誤。
![image](https://user-images.githubusercontent.com/6713645/114711825-b2940180-9d2f-11eb-986c-8628517ab769.png)
