### PR TITLE
Fix compatibility with websockets 9.0 and unpin dependencies

### DIFF
--- a/PyPtt/connect_core.py
+++ b/PyPtt/connect_core.py
@@ -1,6 +1,8 @@
 import time
 import asyncio
 import websockets
+import websockets.http
+import websockets.exceptions
 import telnetlib
 import re
 import traceback

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 progressbar2
-websockets==8.1
+websockets
 uao
 SingleLog
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 progressbar2
-websockets==8.1
+websockets
 uao
 SingleLog

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'progressbar2',
-        'websockets==8.1',
+        'websockets',
         'uao',
         'SingleLog'
     ],


### PR DESCRIPTION
Fixes the following error:

```
$ python -c 'from PyPtt import PTT'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.9/site-packages/PyPtt/PTT.py", line 8, in <module>
    from . import config
  File "/usr/lib/python3.9/site-packages/PyPtt/config.py", line 6, in <module>
    from . import connect_core
  File "/usr/lib/python3.9/site-packages/PyPtt/connect_core.py", line 29, in <module>
    websockets.http.USER_AGENT += f' PyPtt/{version.V}'
  File "/usr/lib/python3.9/site-packages/websockets/imports.py", line 96, in __getattr__
    raise AttributeError(f"module {package!r} has no attribute {name!r}")
AttributeError: module 'websockets' has no attribute 'http'
```

I'm not sure what is the exact issue, but this websockets commit seems
relevant: https://github.com/aaugustin/websockets/commit/42f0e2c0b8e994c33b792208adff32bea1cdff4f