### PR TITLE
增加帳戶是否通過驗證到UserInfo

### DIFF
--- a/PyPtt/_api_get_user.py
+++ b/PyPtt/_api_get_user.py
@@ -41,6 +41,7 @@ def parse_user_page(screen):
             buffer = result_buffer.split(' ')[0]
             # print(f' ==> [{buffer}]')
             result.append(buffer)
+            result.append('同天內只計一次' in result_buffer)
             line = line[line.find(result_buffer) + len(result_buffer):].strip()
             result_buffer = line[6:]
             # print(f' ==> [{result_buffer}]')
@@ -131,8 +132,9 @@ def get_user(api, ptt_id: str) -> data_type.UserInfo:
     ptt_id = data[0]
     money = data[1]
     login_time = int(data[2])
+    account_verified = data[3]
 
-    temp = re.findall(r'\d+', data[3])
+    temp = re.findall(r'\d+', data[4])
     legal_post = int(temp[0])
 
     # PTT2 沒有退文
@@ -141,18 +143,19 @@ def get_user(api, ptt_id: str) -> data_type.UserInfo:
     else:
         illegal_post = -1
 
-    status = data[4]
-    mail = data[5]
-    last_login = data[6]
-    last_ip = data[7]
-    five_chess = data[8]
-    chess = data[9]
+    status = data[5]
+    mail = data[6]
+    last_login = data[7]
+    last_ip = data[8]
+    five_chess = data[9]
+    chess = data[10]
 
     signature_file = '\n'.join(ori_screen.split('\n')[6:-1])
 
     log.show_value(api.config, log.level.DEBUG, 'ptt_id', ptt_id)
     log.show_value(api.config, log.level.DEBUG, 'money', money)
     log.show_value(api.config, log.level.DEBUG, 'login_time', login_time)
+    log.show_value(api.config, log.level.DEBUG, 'account_verified', account_verified)
     log.show_value(api.config, log.level.DEBUG, 'legal_post', legal_post)
     log.show_value(api.config, log.level.DEBUG, 'illegal_post', illegal_post)
     log.show_value(api.config, log.level.DEBUG, 'status', status)
@@ -168,6 +171,7 @@ def get_user(api, ptt_id: str) -> data_type.UserInfo:
         ptt_id,
         money,
         login_time,
+        account_verified,
         legal_post,
         illegal_post,
         status,

--- a/PyPtt/data_type.py
+++ b/PyPtt/data_type.py
@@ -144,6 +144,7 @@ class UserInfo:
             ptt_id,
             money,
             login_time,
+            account_verified,
             legal_post,
             illegal_post,
             status,
@@ -156,6 +157,7 @@ class UserInfo:
         self.id: str = parse_para(str, ptt_id)
         self.money: str = parse_para(str, money)
         self.login_time: int = parse_para(int, login_time)
+        self.account_verified: bool = parse_para(bool, account_verified)
         self.legal_post: int = parse_para(int, legal_post)
         self.illegal_post: int = parse_para(int, illegal_post)
         self.status: str = parse_para(str, status)

--- a/test.py
+++ b/test.py
@@ -850,6 +850,7 @@ def get_user():
             ptt_bot.log('使用者ID: ' + user.id)
             ptt_bot.log('使用者經濟狀況: ' + str(user.money))
             ptt_bot.log('登入次數: ' + str(user.login_time))
+            ptt_bot.log('帳戶通過認證: ' + str(user.account_verified))
             ptt_bot.log('有效文章數: ' + str(user.legal_post))
             ptt_bot.log('退文文章數: ' + str(user.illegal_post))
             ptt_bot.log('目前動態: ' + user.status)


### PR DESCRIPTION
此PR將該帳戶是否有通過認證的資訊加入get_user功能中，要勞煩您費心審閱了

![image](https://user-images.githubusercontent.com/6713645/146670447-e02da88c-d521-4d2f-9a29-dbc3ed34f697.png)
該欄位可能出現的情況，分別為未通過認證及通過認證

- 《登入次數》1 次 (尚未通過認證) 
- 《登入次數》1 次 (同天內只計一次)

本地端測試資訊
```
[1219 10:39:04][外部] eaticecube
[1219 10:39:05][資訊] 批踢踢訊息 [取得使用者成功]
[1219 10:39:05][外部] 使用者ID: eaticecube (亦艾苦)
[1219 10:39:05][外部] 使用者經濟狀況: 家徒四壁
[1219 10:39:05][外部] 登入次數: 18
[1219 10:39:05][外部] 帳戶通過認證: False
[1219 10:39:05][外部] 有效文章數: 0
[1219 10:39:05][外部] 退文文章數: 0
[1219 10:39:05][外部] 目前動態: 不在站上
[1219 10:39:05][外部] 信箱狀態: 最近無新信件
[1219 10:39:05][外部] 最後登入時間: 10/15/2021 03:13:56 Fri
[1219 10:39:05][外部] 上次故鄉: 193.81.213.43
[1219 10:39:05][外部] 五子棋戰績: 0 勝   0 敗   0 和
[1219 10:39:05][外部] 象棋戰績:0 勝   0 敗   0 和
[1219 10:39:05][外部] 簽名檔:
《個人名片》eaticecube 目前沒有名片
[1219 10:39:05][外部] =====================
[1219 10:39:05][外部] CodingMan
[1219 10:39:07][資訊] 批踢踢訊息 [取得使用者成功]
[1219 10:39:07][外部] 使用者ID: CodingMan (bug maker)
[1219 10:39:07][外部] 使用者經濟狀況: 小康
[1219 10:39:07][外部] 登入次數: 1889
[1219 10:39:07][外部] 帳戶通過認證: True
[1219 10:39:07][外部] 有效文章數: 32
[1219 10:39:07][外部] 退文文章數: 0
[1219 10:39:07][外部] 目前動態: 不在站上
[1219 10:39:07][外部] 信箱狀態: 最近無新信件
[1219 10:39:07][外部] 最後登入時間: 12/19/2021 17:32:10 Sun
[1219 10:39:07][外部] 上次故鄉: 202.39.156.137
[1219 10:39:07][外部] 五子棋戰績: 0 勝   0 敗   0 和
[1219 10:39:07][外部] 象棋戰績:0 勝   0 敗   0 和
[1219 10:39:07][外部] 簽名檔:
```