### PR TITLE
[bugfix] 修正取得用戶資料失敗時無法正確印出錯誤訊息

### DIFF
--- a/PyPtt/_api_get_user.py
+++ b/PyPtt/_api_get_user.py
@@ -122,8 +122,8 @@ def get_user(api, ptt_id: str) -> data_type.UserInfo:
 
     # data = lib_util.get_sub_string_list(ori_screen, '》', ['《', '\n'])
     data = parse_user_page(ori_screen)
-    if len(data) < 10:
-        print('\n'.join(data))
+    if len(data) < 11:
+        print('\n'.join([str(d) for d in data]))
         print(len(data))
         raise exceptions.ParseError(ori_screen)
 


### PR DESCRIPTION
此錯誤來自於前一個PR，不好意思，要勞煩您費心審閱了

**Issue description**
取得用戶資料失敗時無法正確印出錯誤訊息

**Steps to reproduce**:
不斷使用`ptt_bot.get_user`功能，有罕見機率會出現錯誤

*What's the expected result?*
正確印出錯誤的資料並拋出`exceptions.ParseError`

**What's the actual result?**
出現以下例外
```
  File "...\PyPtt\_api_get_user.py", line 126, in get_user
    print('\n'.join(data))
TypeError: sequence item 3: expected str instance, bool found
```

**Remarks**
來自最近的PR  https://github.com/PttCodingMan/PyPtt/pull/86 
原本data這個list裡面全都是string，現在多一個布林值

